### PR TITLE
feat: adiciona pipe para exibir " - " caso o valor seja vazio

### DIFF
--- a/src/app/components/user-details/user-details.component.html
+++ b/src/app/components/user-details/user-details.component.html
@@ -5,11 +5,11 @@
   </mat-list-item>
     <mat-divider></mat-divider>
   <mat-list-item>
-    <span class="h2">Nome: </span> <span class="h4">{{ user.nome }}</span>
+    <span class="h2">Nome: </span> <span class="h4">{{ user.nome | dashIfEmpty }}</span>
   </mat-list-item>
     <mat-divider></mat-divider>
   <mat-list-item>
-    <span class="h2">Email: </span> <span class="h4">{{ user.email }}</span>
+    <span class="h2">Email: </span> <span class="h4">{{ user.email | dashIfEmpty  }}</span>
   </mat-list-item>
    <mat-divider></mat-divider>
   <mat-list-item>
@@ -25,11 +25,11 @@
   </mat-list-item>
     <mat-divider></mat-divider>
   <mat-list-item>
-    <span class="h2">Função: </span> <span class="h4">{{ user.funcao}}</span>
+    <span class="h2">Função: </span> <span class="h4">{{ user.funcao | dashIfEmpty }}</span>
   </mat-list-item>
     <mat-divider></mat-divider>
   <mat-list-item>
-    <span class="h2">Data de cadastro: </span> <span class="h4">{{ user.dataCadastro | date:'dd/MM/yyyy' }}</span>
+    <span class="h2">Data de cadastro: </span> <span class="h4">{{ user.dataCadastro | date:'dd/MM/yyyy' | dashIfEmpty  }}</span>
   </mat-list-item>
     <mat-divider></mat-divider>
 </mat-list>

--- a/src/app/pipes/dash-if-empty.pipe.ts
+++ b/src/app/pipes/dash-if-empty.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'dashIfEmpty',
+  standalone: false
+})
+export class DashIfEmptyPipe implements PipeTransform {
+
+  transform(value: any): string | any {
+    const IS_EMPTY = value === undefined || value === null || value === '';
+
+    if(IS_EMPTY){
+      return '-';
+    }
+    return value;
+  }
+
+}

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -2,18 +2,21 @@ import { NgModule } from "@angular/core";
 import { PhonePipe } from './phone.pipe';
 import { AdressPipe } from './address.pipe';
 import { StatusPipe } from './status.pipe';
+import { DashIfEmptyPipe } from './dash-if-empty.pipe';
 
 @NgModule({
     declarations: [
     PhonePipe,
     AdressPipe,
     StatusPipe,
+    DashIfEmptyPipe,
     
   ],
     exports: [
         PhonePipe,
         AdressPipe,
-        StatusPipe
+        StatusPipe,
+        DashIfEmptyPipe,
     ],
 })
 export class PipesModule { }

--- a/src/app/pipes/specs/dash-if-empty.pipe.spec.ts
+++ b/src/app/pipes/specs/dash-if-empty.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DashIfEmptyPipe } from './dash-if-empty.pipe';
+
+describe('DashIfEmptyPipe', () => {
+  it('create an instance', () => {
+    const pipe = new DashIfEmptyPipe();
+    expect(pipe).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Adiciona o pipe `dashIfEmpty` para exibir um " - " caso o valor seja nulo ou vazio. Este pipe foi implementado para melhorar a exibição de informações nos detalhes do usuário, garantindo que campos vazios sejam representados de forma clara na interface. O pipe foi aplicado aos campos Nome, Email, Função e Data de cadastro no componente `UserDetails`.